### PR TITLE
Depend only on glacier lib instead whole AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-glacier</artifactId>
             <version>1.12.332</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This will reduce final jar size from 275MB (27MB before upgrade) to 9MB!